### PR TITLE
Add LIB_SUFFIX option to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,10 +108,10 @@ endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
-
+set(LIB_SUFFIX "" CACHE STRING "Define suffix of libdir" )
 set(prefix ${CMAKE_INSTALL_PREFIX})
 set(exec_prefix ${prefix}/bin)
-set(libdir ${prefix}/lib)
+set(libdir ${prefix}/lib${LIB_SUFFIX})
 set(includedir ${prefix}/include)
 get_filename_component(antlr3c_library_path "${ANTLR3C_LIBRARIES}" PATH)
 set(LIBS_PRIVATE "-L${antlr3c_library_path} -lantlr3c")
@@ -195,7 +195,7 @@ configure_file(cmake/BelleSIPConfig.cmake.in
 	@ONLY
 )
 
-set(ConfigPackageLocation lib/cmake/BelleSIP)
+set(ConfigPackageLocation ${libdir}/cmake/BelleSIP)
 install(EXPORT BelleSIPTargets
 	FILE BelleSIPTargets.cmake
 	NAMESPACE BelledonneCommunications::


### PR DESCRIPTION
Red Hat, Fedora and some other distributions use /usr/lib64 for location of libraries to avoid collision when multilib is being used, thus /usr/lib64 should be taken care of.

Fedora packagers build software with %cmake macro, with LIB_SUFFIX defined in rpmbuild to help build this policy, furthermore please view:

http://pkgs.fedoraproject.org/cgit/cmake.git/tree/macros.cmake#n31
